### PR TITLE
Take a reference to a window in GraphicsContext::new, like glutin and wgpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ use winit::window::WindowBuilder;
 fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
-    let mut graphics_context = unsafe { GraphicsContext::new(window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::RedrawRequested(window_id) if window_id == graphics_context.window().id() => {
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
                 let (width, height) = {
-                    let size = graphics_context.window().inner_size();
+                    let size = window.inner_size();
                     (size.width, size.height)
                 };
                 let buffer = (0..((width * height) as usize))
@@ -93,7 +93,7 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == graphics_context.window().id() => {
+            } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
             _ => {}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use winit::window::WindowBuilder;
 fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
-    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window, &window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -25,7 +25,7 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
 
     let mut old_size = (0, 0);
     let mut frames = pre_render_frames(0, 0);
@@ -35,10 +35,10 @@ fn main() {
         *control_flow = ControlFlow::Poll;
 
         match event {
-            Event::RedrawRequested(window_id) if window_id == graphics_context.window().id() => {
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
                 let elapsed = start.elapsed().as_secs_f64() % 1.0;
                 let (width, height) = {
-                    let size = graphics_context.window().inner_size();
+                    let size = window.inner_size();
                     (size.width, size.height)
                 };
 
@@ -51,12 +51,12 @@ fn main() {
                 graphics_context.set_buffer(buffer.as_slice(), width as u16, height as u16);
             }
             Event::MainEventsCleared => {
-                graphics_context.window().request_redraw();
+                window.request_redraw();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == graphics_context.window().id() => {
+            } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
             _ => {}

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -25,7 +25,7 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window, &window) }.unwrap();
 
     let mut old_size = (0, 0);
     let mut frames = pre_render_frames(0, 0);

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -32,7 +32,7 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window, &window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -32,19 +32,19 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::RedrawRequested(window_id) if window_id == graphics_context.window().id() => {
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
                 graphics_context.set_buffer(&buffer, fruit.width() as u16, fruit.height() as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == graphics_context.window().id() => {
+            } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
             _ => {}

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -21,15 +21,15 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::RedrawRequested(window_id) if window_id == graphics_context.window().id() => {
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
                 let (width, height) = {
-                    let size = graphics_context.window().inner_size();
+                    let size = window.inner_size();
                     (size.width, size.height)
                 };
                 let buffer = (0..((width * height) as usize))
@@ -51,7 +51,7 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == graphics_context.window().id() => {
+            } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
             _ => {}

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -21,7 +21,7 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window, &window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -24,7 +24,7 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window, &window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -24,13 +24,13 @@ fn main() {
             .unwrap();
     }
 
-    let mut graphics_context = unsafe { GraphicsContext::new(window) }.unwrap();
+    let mut graphics_context = unsafe { GraphicsContext::new(&window) }.unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::RedrawRequested(window_id) if window_id == graphics_context.window().id() => {
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
                 let buffer = (0..((BUFFER_WIDTH * BUFFER_HEIGHT) as usize))
                     .map(|index| {
                         let y = index / (BUFFER_WIDTH as usize);
@@ -50,7 +50,7 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == graphics_context.window().id() => {
+            } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
             _ => {}

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,5 +1,5 @@
 use crate::{GraphicsContextImpl, SwBufError};
-use raw_window_handle::{HasRawWindowHandle, AppKitWindowHandle};
+use raw_window_handle::AppKitWindowHandle;
 use core_graphics::base::{kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault};
 use core_graphics::color_space::CGColorSpace;
 use core_graphics::data_provider::CGDataProvider;
@@ -17,7 +17,7 @@ pub struct CGImpl {
 }
 
 impl CGImpl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: AppKitWindowHandle) -> Result<Self, SwBufError<W>> {
+    pub unsafe fn new(handle: AppKitWindowHandle) -> Result<Self, SwBufError> {
         let view = handle.ns_view as id;
         let layer = CALayer::new();
         let subview: id = NSView::alloc(nil).initWithFrame_(view.frame());

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,13 @@
 use std::error::Error;
-use raw_window_handle::{HasRawWindowHandle, RawDisplayHandle, RawWindowHandle};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum SwBufError<W: HasRawWindowHandle> {
+pub enum SwBufError {
     #[error(
         "The provided window returned an unsupported platform: {human_readable_window_platform_name}, {human_readable_display_platform_name}."
     )]
     UnsupportedPlatform {
-        window: W,
         human_readable_window_platform_name: &'static str,
         human_readable_display_platform_name: &'static str,
         window_handle: RawWindowHandle,
@@ -19,7 +18,7 @@ pub enum SwBufError<W: HasRawWindowHandle> {
 }
 
 #[allow(unused)] // This isn't used on all platforms
-pub(crate) fn unwrap<T, E: std::error::Error + 'static, W: HasRawWindowHandle>(res: Result<T, E>, str: &str) -> Result<T, SwBufError<W>>{
+pub(crate) fn unwrap<T, E: std::error::Error + 'static>(res: Result<T, E>, str: &str) -> Result<T, SwBufError>{
     match res{
         Ok(t) => Ok(t),
         Err(e) => Err(SwBufError::PlatformError(Some(str.into()), Some(Box::new(e))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,17 @@ pub struct GraphicsContext {
 }
 
 impl GraphicsContext {
-    /// Creates a new instance of this struct, using the provided window.
+    /// Creates a new instance of this struct, using the provided window and display.
     ///
     /// # Safety
     ///
-    ///  - Ensure that the provided window is valid to draw a 2D buffer to, and is valid for the
+    ///  - Ensure that the provided objects are valid to draw a 2D buffer to, and are valid for the
     ///    lifetime of the GraphicsContext
-    pub unsafe fn new<W: HasRawWindowHandle + HasRawDisplayHandle>(window: &W) -> Result<Self, SwBufError> {
-        Self::from_raw(window.raw_window_handle(), window.raw_display_handle())
+    pub unsafe fn new<W: HasRawWindowHandle, D: HasRawDisplayHandle>(window: &W, display: &D) -> Result<Self, SwBufError> {
+        Self::from_raw(window.raw_window_handle(), display.raw_display_handle())
     }
 
-    /// Creates a new instance of this struct, using the provided raw handles
+    /// Creates a new instance of this struct, using the provided raw window and display handles
     ///
     /// # Safety
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,16 +33,23 @@ pub struct GraphicsContext {
 }
 
 impl GraphicsContext {
-    /// Creates a new instance of this struct, consuming the given window.
+    /// Creates a new instance of this struct, using the provided window.
     ///
     /// # Safety
     ///
-    ///  - Ensure that the passed object is valid to draw a 2D buffer to, and is valid for the
+    ///  - Ensure that the provided window is valid to draw a 2D buffer to, and is valid for the
     ///    lifetime of the GraphicsContext
     pub unsafe fn new<W: HasRawWindowHandle + HasRawDisplayHandle>(window: &W) -> Result<Self, SwBufError> {
-        let raw_window_handle = window.raw_window_handle();
-        let raw_display_handle = window.raw_display_handle();
+        Self::from_raw(window.raw_window_handle(), window.raw_display_handle())
+    }
 
+    /// Creates a new instance of this struct, using the provided raw handles
+    ///
+    /// # Safety
+    ///
+    ///  - Ensure that the provided handles are valid to draw a 2D buffer to, and are valid for the
+    ///    lifetime of the GraphicsContext
+    pub unsafe fn from_raw(raw_window_handle: RawWindowHandle, raw_display_handle: RawDisplayHandle) -> Result<Self, SwBufError> {
         let imple: Box<dyn GraphicsContextImpl> = match (raw_window_handle, raw_display_handle) {
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             (RawWindowHandle::Xlib(xlib_window_handle), RawDisplayHandle::Xlib(xlib_display_handle)) => Box::new(x11::X11Impl::new(xlib_window_handle, xlib_display_handle)?),

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -1,4 +1,3 @@
-use raw_window_handle::HasRawWindowHandle;
 use raw_window_handle::OrbitalWindowHandle;
 use std::{
     cmp,
@@ -47,7 +46,7 @@ pub struct OrbitalImpl {
 }
 
 impl OrbitalImpl {
-    pub fn new<W: HasRawWindowHandle>(handle: OrbitalWindowHandle) -> Result<Self, SwBufError<W>> {
+    pub fn new(handle: OrbitalWindowHandle) -> Result<Self, SwBufError> {
         Ok(Self { handle })
     }
 }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -1,6 +1,6 @@
 use crate::{error::unwrap, GraphicsContextImpl, SwBufError};
 use nix::sys::memfd::{memfd_create, MemFdCreateFlag};
-use raw_window_handle::{HasRawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle};
+use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle};
 use std::{
     ffi::CStr,
     fs::File,
@@ -40,10 +40,10 @@ impl Drop for WaylandBuffer {
 }
 
 impl WaylandImpl {
-    pub unsafe fn new<W: HasRawWindowHandle>(
+    pub unsafe fn new(
         window_handle: WaylandWindowHandle,
         display_handle: WaylandDisplayHandle,
-    ) -> Result<Self, SwBufError<W>> {
+    ) -> Result<Self, SwBufError> {
         let conn = Connection::from_backend(Backend::from_foreign_display(
             display_handle.display as *mut _,
         ));

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,4 +1,3 @@
-use raw_window_handle::HasRawWindowHandle;
 use raw_window_handle::WebWindowHandle;
 use wasm_bindgen::Clamped;
 use wasm_bindgen::JsCast;
@@ -15,7 +14,7 @@ pub struct WebImpl {
 }
 
 impl WebImpl {
-    pub fn new<W: HasRawWindowHandle>(handle: WebWindowHandle) -> Result<Self, SwBufError<W>> {
+    pub fn new(handle: WebWindowHandle) -> Result<Self, SwBufError> {
         let canvas: HtmlCanvasElement = web_sys::window()
             .ok_or_else(|| {
                 SwBufError::PlatformError(

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,5 +1,5 @@
 use crate::{GraphicsContextImpl, SwBufError};
-use raw_window_handle::{HasRawWindowHandle, Win32WindowHandle};
+use raw_window_handle::Win32WindowHandle;
 use std::os::raw::c_int;
 
 use windows_sys::Win32::Foundation::HWND;
@@ -22,7 +22,7 @@ struct BitmapInfo {
 }
 
 impl Win32Impl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: &Win32WindowHandle) -> Result<Self, crate::SwBufError<W>> {
+    pub unsafe fn new(handle: &Win32WindowHandle) -> Result<Self, crate::SwBufError> {
         let dc = GetDC(handle.hwnd as HWND);
 
         if dc == 0 {

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -1,5 +1,5 @@
 use crate::{GraphicsContextImpl, SwBufError};
-use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle, XlibDisplayHandle, XlibWindowHandle};
+use raw_window_handle::{XlibDisplayHandle, XlibWindowHandle};
 use std::os::raw::{c_char, c_uint};
 use x11_dl::xlib::{Display, Visual, Xlib, ZPixmap, GC};
 
@@ -13,7 +13,7 @@ pub struct X11Impl {
 }
 
 impl X11Impl {
-    pub unsafe fn new<W: HasRawWindowHandle + HasRawDisplayHandle>(window_handle: XlibWindowHandle, display_handle: XlibDisplayHandle) -> Result<Self, SwBufError<W>> {
+    pub unsafe fn new(window_handle: XlibWindowHandle, display_handle: XlibDisplayHandle) -> Result<Self, SwBufError> {
         let lib = match Xlib::open() {
             Ok(lib) => lib,
             Err(e) => return Err(SwBufError::PlatformError(Some("Failed to open Xlib".into()), Some(Box::new(e))))


### PR DESCRIPTION
This aligns the API with glutin (see https://docs.rs/glutin/latest/glutin/surface/struct.SurfaceAttributesBuilder.html#method.build and https://docs.rs/glutin/latest/glutin/display/enum.Display.html#method.create_window_surface) and wgpu (see https://docs.rs/wgpu/latest/wgpu/struct.Instance.html#method.create_surface). This makes it easier to use swbuf in places like iced where the winit window is used separately from the rendering context.

I have tested on the following platforms:

- [x] macOS
- [x] Redox OS (with https://github.com/rust-windowing/winit/pull/2588)
- [x] X11
- [x] Windows

I need help testing on these platforms:

- [x] Wayland (cc: @ids1024)
- [ ] Web