### PR TITLE
Use static dispatch

### DIFF
--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,4 +1,4 @@
-use crate::{GraphicsContextImpl, SwBufError};
+use crate::SwBufError;
 use raw_window_handle::AppKitWindowHandle;
 use core_graphics::base::{kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault};
 use core_graphics::color_space::CGColorSpace;
@@ -32,10 +32,8 @@ impl CGImpl {
         let _: () = msg_send![subview, release]; // releases subview (-1) = 1
         Ok(Self{layer})
     }
-}
 
-impl GraphicsContextImpl for CGImpl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         let color_space = CGColorSpace::create_device_rgb();
         let data = std::slice::from_raw_parts(
             buffer.as_ptr() as *const u8,

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -5,7 +5,6 @@ use std::{
     str,
 };
 
-use crate::GraphicsContextImpl;
 use crate::SwBufError;
 
 struct OrbitalMap {
@@ -49,10 +48,8 @@ impl OrbitalImpl {
     pub fn new(handle: OrbitalWindowHandle) -> Result<Self, SwBufError> {
         Ok(Self { handle })
     }
-}
 
-impl GraphicsContextImpl for OrbitalImpl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width_u16: u16, height_u16: u16) {
+    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width_u16: u16, height_u16: u16) {
         let window_fd = self.handle.window as usize;
 
         // Read the current width and size

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::unwrap, GraphicsContextImpl, SwBufError};
+use crate::{error::unwrap, SwBufError};
 use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle};
 use std::collections::VecDeque;
 use wayland_client::{
@@ -78,10 +78,8 @@ impl WaylandImpl {
         self.buffers.push_back(buffer);
         self.buffers.back().unwrap()
     }
-}
 
-impl GraphicsContextImpl for WaylandImpl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+    pub(super) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         let _ = self.event_queue.dispatch_pending(&mut State);
 
         let surface = self.surface.clone();

--- a/src/web.rs
+++ b/src/web.rs
@@ -5,7 +5,6 @@ use web_sys::CanvasRenderingContext2d;
 use web_sys::HtmlCanvasElement;
 use web_sys::ImageData;
 
-use crate::GraphicsContextImpl;
 use crate::SwBufError;
 
 pub struct WebImpl {
@@ -60,10 +59,8 @@ impl WebImpl {
 
         Ok(Self { canvas, ctx })
     }
-}
 
-impl GraphicsContextImpl for WebImpl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         self.canvas.set_width(width.into());
         self.canvas.set_height(height.into());
 

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,12 +1,12 @@
 //! Implementation of software buffering for Windows.
-//! 
+//!
 //! This module converts the input buffer into a bitmap and then stretches it to the window.
 
-use crate::{GraphicsContextImpl, SwBufError};
+use crate::SwBufError;
 use raw_window_handle::Win32WindowHandle;
 
-use std::mem;
 use std::io;
+use std::mem;
 use std::os::raw::c_int;
 
 use windows_sys::Win32::Foundation::HWND;
@@ -33,9 +33,9 @@ struct BitmapInfo {
 
 impl Win32Impl {
     /// Create a new `Win32Impl` from a `Win32WindowHandle`.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// The `Win32WindowHandle` must be a valid window handle.
     pub unsafe fn new(handle: &Win32WindowHandle) -> Result<Self, crate::SwBufError> {
         // It is valid for the window handle to be null here. Error out if it is.
@@ -56,17 +56,12 @@ impl Win32Impl {
             ));
         }
 
-        Ok(Self {
-            dc,
-            window: hwnd,
-        })
+        Ok(Self { dc, window: hwnd })
     }
-}
 
-impl GraphicsContextImpl for Win32Impl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         // Create a new bitmap info struct.
-        let mut bitmap_info: BitmapInfo =mem::zeroed();
+        let mut bitmap_info: BitmapInfo = mem::zeroed();
 
         bitmap_info.bmi_header.biSize = mem::size_of::<BITMAPINFOHEADER>() as u32;
         bitmap_info.bmi_header.biPlanes = 1;

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -1,10 +1,10 @@
 //! Implementation of software buffering for X11.
-//! 
+//!
 //! This module converts the input buffer into an XImage and then sends it over the wire to be
 //! drawn. A more effective implementation would use shared memory instead of the wire. In
 //! addition, we may also want to blit to a pixmap instead of a window.
 
-use crate::{GraphicsContextImpl, SwBufError};
+use crate::SwBufError;
 use raw_window_handle::{XlibDisplayHandle, XlibWindowHandle};
 use std::os::raw::{c_char, c_uint};
 use x11_dl::xlib::{Display, Visual, Xlib, ZPixmap, GC};
@@ -32,9 +32,9 @@ pub struct X11Impl {
 
 impl X11Impl {
     /// Create a new `X11Impl` from a `XlibWindowHandle` and `XlibDisplayHandle`.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// The `XlibWindowHandle` and `XlibDisplayHandle` must be valid.
     pub unsafe fn new(
         window_handle: XlibWindowHandle,
@@ -83,10 +83,8 @@ impl X11Impl {
             depth,
         })
     }
-}
 
-impl GraphicsContextImpl for X11Impl {
-    unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         // Create the image from the buffer.
         let image = (self.lib.XCreateImage)(
             self.display_handle.display as *mut Display,


### PR DESCRIPTION
At the moment, this crate uses dynamic dispatch to differentiate among different operating systems. However, for certain systems (e.g. Windows) there is only one available backend, so it's kind of a waste. This PR replaces it with static enum dispatch, which the compiler should optimize out much better.