### PR TITLE
Fix scaling of the buffer on macOS

### DIFF
--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -16,7 +16,10 @@ fn main() {
     }).collect::<Vec<_>>();
 
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = WindowBuilder::new()
+        .with_inner_size(winit::dpi::PhysicalSize::new(fruit.width(), fruit.height()))
+        .build(&event_loop)
+        .unwrap();
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -6,7 +6,7 @@ use core_graphics::data_provider::CGDataProvider;
 use core_graphics::image::CGImage;
 
 use cocoa::base::{id, nil};
-use cocoa::appkit::{NSView, NSViewWidthSizable, NSViewHeightSizable};
+use cocoa::appkit::{NSView, NSViewWidthSizable, NSViewHeightSizable, NSWindow};
 use cocoa::quartzcore::{CALayer, ContentsGravity};
 use foreign_types::ForeignType;
 
@@ -18,11 +18,13 @@ pub struct CGImpl {
 
 impl CGImpl {
     pub unsafe fn new(handle: AppKitWindowHandle) -> Result<Self, SwBufError> {
+        let window = handle.ns_window as id;
         let view = handle.ns_view as id;
         let layer = CALayer::new();
-        let subview: id = NSView::alloc(nil).initWithFrame_(view.frame());
+        let subview: id = NSView::alloc(nil).initWithFrame_(NSView::frame(view));
         layer.set_contents_gravity(ContentsGravity::TopLeft);
         layer.set_needs_display_on_bounds_change(false);
+        layer.set_contents_scale(window.backingScaleFactor());
         subview.setLayer(layer.id());
         subview.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable);
 


### PR DESCRIPTION
Currently the size of the buffer on macOS is interpreted in logical pixels, which
is inconsistent with the other platforms. Instead,
we should apply the same scale factor that applies to regular rendering.
