### PR TITLE
ci: Add rustfmt/clippy to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
     branches: [main]
 
 jobs:
+  Check_Formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+        components: rustfmt
+    - name: Check Formatting
+      run: cargo +stable fmt --all -- --check
+
   tests:
     name: Tests
     strategy:


### PR DESCRIPTION
This PR is split off from #21, and runs Rustfmt/Clippy in the CI to ensure that the code style is always proper.